### PR TITLE
Desaturate recolored icons, better color render

### DIFF
--- a/tullaRange/tullaRange.lua
+++ b/tullaRange/tullaRange.lua
@@ -292,6 +292,7 @@ function Addon:SetButtonState(button, state, force)
 
     local r, g, b, a = self:GetColor(state)
 
+    button.icon:SetDesaturated(state ~= 'normal')
     button.icon:SetVertexColor(r, g, b, a)
 end
 


### PR DESCRIPTION
Applying desaturation on recolored icons make the
recolored icons render better, especially when their default colors are nearly mono-chromatic.